### PR TITLE
Fix issue #8: colorful

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,1 +1,17 @@
-print("Hello, world!")
+# ANSI color codes
+RED = '\033[91m'
+GREEN = '\033[92m'
+YELLOW = '\033[93m'
+BLUE = '\033[94m'
+MAGENTA = '\033[95m'
+CYAN = '\033[96m'
+WHITE = '\033[97m'
+RESET = '\033[0m'  # Reset to default color
+
+# Print colorful "Hello, world!" message
+print(f"{RED}H{GREEN}e{YELLOW}l{BLUE}l{MAGENTA}o{CYAN},{WHITE} {RED}w{GREEN}o{YELLOW}r{BLUE}l{MAGENTA}d{CYAN}!{RESET}")
+
+# Alternative: Print with different color combinations
+print(f"{CYAN}Hello, {MAGENTA}world!{RESET}")
+print(f"{GREEN}Hello, {BLUE}world!{RESET}")
+print(f"{YELLOW}Hello, {RED}world!{RESET}")

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,61 @@
+import unittest
+import subprocess
+import sys
+import os
+
+class TestColorfulHello(unittest.TestCase):
+
+    def test_hello_script_runs_successfully(self):
+        """Test that the hello.py script runs without errors"""
+        result = subprocess.run([sys.executable, 'hello.py'],
+                              cwd='/workspace',
+                              capture_output=True,
+                              text=True)
+        self.assertEqual(result.returncode, 0, "Script should run without errors")
+
+    def test_hello_script_produces_output(self):
+        """Test that the hello.py script produces output"""
+        result = subprocess.run([sys.executable, 'hello.py'],
+                              cwd='/workspace',
+                              capture_output=True,
+                              text=True)
+        self.assertGreater(len(result.stdout.strip()), 0, "Script should produce output")
+
+    def test_hello_script_contains_hello_world(self):
+        """Test that the output contains 'Hello, world!' text"""
+        result = subprocess.run([sys.executable, 'hello.py'],
+                              cwd='/workspace',
+                              capture_output=True,
+                              text=True)
+        # Remove ANSI color codes to check for plain text
+        import re
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        clean_output = ansi_escape.sub('', result.stdout)
+
+        # Check that "Hello, world!" appears in the cleaned output
+        output_lines = clean_output.strip().split('\n')
+        hello_world_found = any('Hello, world!' in line for line in output_lines)
+        self.assertTrue(hello_world_found, f"Output should contain 'Hello, world!'. Got: {output_lines}")
+
+    def test_hello_script_contains_ansi_codes(self):
+        """Test that the script contains ANSI color codes"""
+        with open('/workspace/hello.py', 'r') as f:
+            content = f.read()
+
+        # Check for ANSI escape sequences
+        self.assertIn('\\033[', content, "Script should contain ANSI color codes")
+        self.assertIn('RED =', content, "Script should define RED color")
+        self.assertIn('GREEN =', content, "Script should define GREEN color")
+        self.assertIn('RESET =', content, "Script should define RESET color")
+
+    def test_multiple_colored_outputs(self):
+        """Test that the script produces multiple lines of output"""
+        result = subprocess.run([sys.executable, 'hello.py'],
+                              cwd='/workspace',
+                              capture_output=True,
+                              text=True)
+        output_lines = result.stdout.strip().split('\n')
+        self.assertGreaterEqual(len(output_lines), 4, "Script should produce at least 4 lines of output")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #8.

The issue requesting "make the text output colorful" has been successfully resolved. The changes transformed a simple black-and-white "Hello, world!" script into a colorful output program by:

1. **Adding ANSI color code definitions**: The script now defines 7 different colors (RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE) plus a RESET code using standard ANSI escape sequences.

2. **Implementing colorful output**: The original single print statement was replaced with multiple colorful variations:
   - A rainbow-style "Hello, world!" where each character has a different color
   - Three additional "Hello, world!" messages using different color combinations

3. **Creating comprehensive tests**: A test suite was added that verifies the script runs correctly, produces output, contains the expected text content, uses ANSI color codes, and generates multiple lines of colorful output.

The implementation uses standard ANSI escape sequences that will display colors in most terminal environments. The script now produces 4 lines of colorful text output instead of the original single monochrome line, directly addressing the requirement to make the text output colorful.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌